### PR TITLE
corrigindo leitura -> lendo sempre o último índice

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -12,7 +12,7 @@ STATUS_INVALID_FILE = 5
 def _read(file, month, year):
     try:
         data = pd.read_html(file, decimal=',', thousands='.')
-        data = data[0]
+        data = data[-1]
         data = data[: -1]
         data = data.to_numpy()
     except Exception as excep:

--- a/src/data.py
+++ b/src/data.py
@@ -13,7 +13,6 @@ def _read(file, month, year):
     try:
         data = pd.read_html(file, decimal=',', thousands='.')
         data = data[-1]
-        data = data[: -1]
         data = data.to_numpy()
     except Exception as excep:
         if str(excep) == "No tables found":


### PR DESCRIPTION
- corrigindo erro de coleta: "Error 7: error loading datapackage (/home/runner/work/executor-automatizado/executor-automatizado/output/mpmg_01_2024/output/mpmg-2024-1.zip):\"failed to cast ContraCheque_CSV: [{0 the row with 0 values does not match the 13 fields in the schema}]\""
- erro se dava devido ao campo **folha** do proto estar vazia, que por sua vez acontecia devido ao coletor não acessar o índice da planilha corretamente.